### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<joda.time.version>2.3</joda.time.version>
 		<guava.version>16.0.1</guava.version>
 		<javax.inject.version>1</javax.inject.version>
-		<apache.commons.version>3.2.1</apache.commons.version>
+		<apache.commons.version>3.2.2</apache.commons.version>
 		<apache.commons.io.version>2.4</apache.commons.io.version>
 		<google.collections.version>1.0</google.collections.version>
 		<eaio.uuid.version>3.2</eaio.uuid.version>


### PR DESCRIPTION
Upgrade Apache Commons Collections to v3.2.2

Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/